### PR TITLE
Modified the method definitions for SetNext and SetPrevious to return…

### DIFF
--- a/ProcessFlow/Flow/SetOptionsConvergeResult.cs
+++ b/ProcessFlow/Flow/SetOptionsConvergeResult.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ProcessFlow.Flow
+{
+    /// <summary>
+    /// An object that is used as the return type for <see
+    /// cref="StepExtensions.SetOptionsConverge{T}(SingleStepSelector{T}, List{Steps.Step{T}})"/>.
+    /// The purpose of this type is to be able to set the next step for each step within the
+    /// options list.
+    /// </summary>
+    /// <typeparam name="T">The type of the state object.</typeparam>
+    public class SetOptionsConvergeResult<T>
+        where T : class
+    {
+        private readonly List<Steps.Step<T>> _options;
+
+        public SetOptionsConvergeResult(List<Steps.Step<T>> options)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        /// <summary>
+        /// Sets the next step for each of the steps in the options list and then returns the
+        /// object passed into <paramref name="step"/>.
+        /// </summary>
+        /// <param name="step">The step to set as the next step for all steps in the options list.</param>
+        /// <returns>The object passed into <paramref name="step"/>.</returns>
+        public TStep SetNext<TStep>(TStep step)
+            where TStep : Steps.Step<T>
+        {
+            foreach (var option in _options)
+            {
+                option.SetNext(step);
+            }
+
+            return step;
+        }
+    }
+}

--- a/ProcessFlow/Flow/Step.cs
+++ b/ProcessFlow/Flow/Step.cs
@@ -118,16 +118,18 @@ namespace ProcessFlow.Flow
                 return workflowState;
         }
 
-        public Step<T> SetNext(Step<T> processor)
+        public TStep SetNext<TStep>(TStep processor)
+            where TStep : Step<T>
         {
             _next = processor;
-            return _next;
+            return processor;
         }
 
-        public Step<T> SetPrevious(Step<T> processor)
+        public TStep SetPrevious<TStep>(TStep processor)
+            where TStep : Step<T>
         {
             _previous = processor;
-            return _previous;
+            return processor;
         }
     }
 }

--- a/ProcessFlow/Interfaces/IStep.cs
+++ b/ProcessFlow/Interfaces/IStep.cs
@@ -12,8 +12,13 @@ namespace ProcessFlow.Interfaces
         Step<T> Next();
         Step<T> Previous();
         Task<WorkflowState<T>> Process(WorkflowState<T> workflowState);
-        Step<T> SetNext(Step<T> processor);
-        Step<T> SetPrevious(Step<T> processor);
+
+        TStep SetNext<TStep>(TStep processor)
+            where TStep : Step<T>;
+
+        TStep SetPrevious<TStep>(TStep processor)
+            where TStep : Step<T>;
+
         Step<T> SetProcessor(IProcessor<T> processor);
     }
 }

--- a/ProcessFlow/Steps/SingleStepSelector.cs
+++ b/ProcessFlow/Steps/SingleStepSelector.cs
@@ -1,4 +1,5 @@
 ﻿using ProcessFlow.Data;
+using ProcessFlow.Flow;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -21,6 +22,24 @@ namespace ProcessFlow.Steps
         {
             _options = options;
             return this;
+        }
+
+        /// <summary>
+        /// Sets the options for a <see cref="SingleStepSelector{T}"/> object and then returns an
+        /// object that can be used to set the next step for each step in <paramref
+        /// name="options"/> to the same next step. If any of the values in <paramref
+        /// name="options"/> need to have a different next step, do not use this method. This
+        /// method is only designed to be used when there is a temporary, one stage split and then
+        /// the workflow converges immediately afterwards.
+        /// </summary>
+        /// <param name="stepSelector">The step that the options will be applied to.</param>
+        /// <param name="options">The options to be applied to <paramref name="source"/>.</param>
+        /// <returns>An object that can be used to set the next step for all steps in <paramref name="options"/>.</returns>
+        public SetOptionsConvergeResult<T> SetOptionsConverge(List<Step<T>> options)
+        {
+            SetOptions(options);
+
+            return new SetOptionsConvergeResult<T>(options);
         }
 
         protected override async Task<WorkflowState<T>> ExecuteExtensionProcess(WorkflowState<T> workflowState)


### PR DESCRIPTION
… the exact type that is passed in. Also added a new method called SetOptionsConverge which sets the next step for all options to be the same step.

The changes should be drop in compatible with existing code.